### PR TITLE
Add title tag to default layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 #
@@ -18,20 +18,19 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-title: Ginger engineering blog
+title: Ginger Engineering Blog
 email: engineering-blog@ginger.io
 description: >- # this means to ignore newlines until "baseurl:"
 #This is Ginger's engineering blog
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://ginger-io.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: ginger_io
-github_username:  ginger-io
+github_username: ginger-io
 
 # Build settings
 theme: minima
 plugins:
   - jekyll-feed
-
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,9 @@
 
     <link rel="stylesheet" href="/assets/css/bulma.min.css" media="all" />
     <link rel="stylesheet" href="/assets/css/main.css" media="all" />
+    <title>
+      {% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}
+    </title>
   </head>
   <body>
     <nav class="mainNav">
@@ -24,8 +27,6 @@
       </div>
     </nav>
 
-    <div class="container content">
-      {{ content }}
-    </div>
+    <div class="container content"> {{ content }} </div>
   </body>
 </html>

--- a/about.markdown
+++ b/about.markdown
@@ -4,4 +4,4 @@ title: About
 permalink: /about/
 ---
 
-This is the blog for [Ginger's](https://ginger.io) engineering, data science and security team 
+This is the blog for [Ginger's](https://ginger.io) engineering, data science and security teams.


### PR DESCRIPTION
I was looking at the transformers-embeddings blogpost published in #6 and #7 and realized it was missing the `title` tag, so the URL was being displayed in the browser instead.

This PR adds the missing `title` tag to the HTML layout. Next PR is applying this layout to the existing pages.